### PR TITLE
Multiple replies

### DIFF
--- a/src/Singer/Model.hs
+++ b/src/Singer/Model.hs
@@ -2,26 +2,37 @@
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Singer.Model
-  (
-    Tweet(..)
+  ( Tweet(..)
   , TweetId(..)
   , Thread(..)
   , TweetSrc(..)
   , TweetAncestors
   , fromTweetSrc
   , mkThread
-  ) where
+  )
+where
 
-import           Data.Aeson         (FromJSON (..), camelTo2, defaultOptions,
-                                     fieldLabelModifier, genericParseJSON)
-import           Data.Foldable      (foldl')
-import           Data.List.NonEmpty (unfoldr)
-import qualified Data.List.NonEmpty as NE (head)
-import qualified Data.Map           as M
-import           Data.Text          (Text, unpack)
-import           Data.Time          (UTCTime, defaultTimeLocale, parseTimeM)
+import           Control.Monad                  ( guard )
+import           Data.Aeson                     ( FromJSON(..)
+                                                , camelTo2
+                                                , defaultOptions
+                                                , fieldLabelModifier
+                                                , genericParseJSON
+                                                )
+import           Data.Monoid                    ( Sum(..) )
+import           Data.Tree                      ( Tree
+                                                , unfoldTree
+                                                )
+import qualified Data.Map                      as M
+import           Data.Text                      ( Text
+                                                , unpack
+                                                )
+import           Data.Time                      ( UTCTime
+                                                , defaultTimeLocale
+                                                , parseTimeM
+                                                )
 import           GHC.Generics
-import           Text.Read          (readMaybe)
+import           Text.Read                      ( readMaybe )
 
 newtype TweetId = TweetId { getTweetId :: Text }
   deriving newtype (Eq, Ord, Show, FromJSON)
@@ -48,38 +59,42 @@ data Tweet =
         , replyTo :: Maybe TweetId
         , date    :: UTCTime
         , content :: Text
-        , child   :: Maybe Tweet
+        , children   :: [Tweet]
         }
   deriving (Eq, Ord, Show)
 
 data Thread =
   Thread { firstTweetAt :: UTCTime
          , totalFav     :: Int
-         , tweets       :: [Text]
+         , tweets       :: Tree Text
          }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Show)
 
-tweetUnfolder :: Tweet -> (Tweet, Maybe Tweet)
-tweetUnfolder t = ( t { child = Nothing }, child t )
+tweetUnfolder :: Tweet -> (Tweet, [Tweet])
+tweetUnfolder t = (t { children = mempty }, children t)
 
 mkThread' :: Tweet -> Thread
 mkThread' t =
-  let unfolded = unfoldr tweetUnfolder t
-      extract (favs, txts) tweet = (favs + favNb tweet, txts <> pure (content tweet))
-      threadLikesAndTexts = foldl' extract (0, mempty) unfolded
-  in uncurry (Thread (date . NE.head $ unfolded)) threadLikesAndTexts
+  let unfolded            = unfoldTree tweetUnfolder t
+      texts               = fmap content unfolded
+      threadLikesAndTexts = getSum $ foldMap (Sum . favNb) unfolded
+  in  Thread (date t) threadLikesAndTexts texts
 
 mkThread :: Tweet -> Maybe Thread
-mkThread t = maybe Nothing (const . pure . mkThread' $ t) $ child t
+mkThread t = do
+  guard (not $ null $ children t)
+  pure $ mkThread' t
 
 fromTweetSrc :: TweetSrc -> Maybe Tweet
 fromTweetSrc (TweetSrc _ fc iRT tId cAt _ fT) =
-  Tweet <$> readMaybe (unpack fc)
-        <*> pure tId
-        <*> pure iRT
-        <*> parseTimeM True defaultTimeLocale "%c" (unpack cAt)
-        <*> pure fT
-        <*> pure Nothing
+  Tweet
+    <$> readMaybe (unpack fc)
+    <*> pure tId
+    <*> pure iRT
+    <*> parseTimeM True defaultTimeLocale "%c" (unpack cAt)
+    <*> pure fT
+    <*> pure mempty
 
 instance FromJSON TweetSrc where
-  parseJSON = genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }
+  parseJSON =
+    genericParseJSON defaultOptions { fieldLabelModifier = camelTo2 '_' }

--- a/src/Singer/Stream.hs
+++ b/src/Singer/Stream.hs
@@ -53,7 +53,7 @@ baseFilter screenName = S.filter (validTweet screenName)
 
 
 data ThreadState = ThreadState
-     { lastTweet     :: Tweet
+     { nextTweet     :: Tweet
      , ongoingThread :: Map TweetId [Tweet]
      } deriving (Show)
 
@@ -116,7 +116,7 @@ extractThread st = let
     guard . not . null $ children t
     mkThread t
 
-  in st >>= go . lastTweet
+  in st >>= go . nextTweet
 
 
 toThread :: (Monad m) => S.Stream (S.Of Tweet) m () -> S.Stream (S.Of Thread) m ()

--- a/src/Singer/Stream.hs
+++ b/src/Singer/Stream.hs
@@ -59,15 +59,9 @@ data ThreadState = ThreadState
 
 addOngoingThread :: Tweet -> Map TweetId [Tweet] -> Map TweetId [Tweet]
 addOngoingThread t ongoing = let
-
-  insertTweet :: Maybe [Tweet] -> Maybe [Tweet]
   insertTweet replies = pure $ t : concat replies
-
-  updateRepliesList :: TweetId -> Map TweetId [Tweet]
   updateRepliesList k = M.alter insertTweet k ongoing
-
   in maybe ongoing updateRepliesList (replyTo t)
-
 
 getAndDelete :: Ord k => k -> Map k v -> (Maybe v, Map k v)
 getAndDelete = M.updateLookupWithKey (const $ const Nothing)
@@ -78,25 +72,14 @@ attachReplies t replies = t {children = concat replies}
 
 handleHead :: Tweet -> ThreadState
 handleHead t = let
-
-  initOngoingThread :: Map TweetId [Tweet]
   initOngoingThread = maybe mempty (`M.singleton` [t]) (replyTo t)
-
   in ThreadState t initOngoingThread
 
 handleTail' :: Tweet -> Map TweetId [Tweet] -> ThreadState
 handleTail' t ongoing = let
-
-  replies :: Maybe [Tweet]
-  ongoing' :: Map TweetId [Tweet]
   (replies, ongoing') = getAndDelete (id_ t) ongoing
-
-  current :: Tweet
   current = attachReplies t replies
-
-  ongoingWithCurrent :: Map TweetId [Tweet]
   ongoingWithCurrent = addOngoingThread current ongoing'
-
   in ThreadState current ongoingWithCurrent
 
 handleTail :: Tweet -> ThreadState -> ThreadState

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -4,14 +4,15 @@ module Spec
     main
   ) where
 
-import Control.Monad (join)
-import Data.Function ((&))
-import Data.Maybe (fromMaybe)
-import Test.Hspec
-import Tweets (fixture)
-import Singer.Stream
-import Singer.Model (Thread(..))
-import Streaming.Prelude (head_)
+import           Control.Monad     (join)
+import           Data.Function     ((&))
+import           Data.Maybe        (fromMaybe)
+import           Data.Tree         (Tree (Node))
+import           Singer.Model      (Thread (..))
+import           Singer.Stream
+import           Streaming.Prelude (head_)
+import           Test.Hspec
+import           Tweets            (fixture)
 
 main :: IO ()
 main = hspec $
@@ -23,4 +24,4 @@ main = hspec $
     it "Even with tweets in between" $
       length (tweets thread) `shouldBe` 3
     it "Threads are in the proper order" $
-      tweets thread `shouldBe` ["Beginning of thread", "Middle of thread", "End of thread"]
+      tweets thread `shouldBe` (Node "Beginning of thread" [Node "Middle of thread" [Node "End of thread" []]])


### PR DESCRIPTION
- Update the model: `child :: Maybe Tweet` is replaced by `children :: [Tweet]` and a `Thread` is now a tree of tweets.
- Update the thread stream accordingly, it can now handle imbricated thread: `startThread1 - startThread2 - replyToThread2 - replyToThread1` should successfully emit 2 threads of 2 tweets (no test yet)
- Update the test to output a Tree of text instead of a list.